### PR TITLE
Track which plugins executed last, pick up where we left off

### DIFF
--- a/runner-template.yaml
+++ b/runner-template.yaml
@@ -23,6 +23,18 @@ objects:
           kind: DockerImage
           name: 'quay.io/cloudservices/iqe-tests:latest'
 
+objects:
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: black-box-runner-storage
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
@@ -74,6 +86,9 @@ objects:
         - name: black-box-runner-src
           configMap:
             name: black-box-runner
+        - name: black-box-runner-storage
+          persistentVolumeClaim:
+            claimName: black-box-runner-storage
         containers:
         - image: iqe-tests:latest
           imagePullPolicy: Always
@@ -116,6 +131,8 @@ objects:
           volumeMounts:
           - name: black-box-runner-src
             mountPath: /black-box-runner
+          - name: black-box-runner-storage
+            mountPath: /black-box-runner-storage
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         schedulerName: default-scheduler

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,7 @@
+import logging
 import os
 
-
+log = logging.getLogger("blackbox.config")
 _this_dir = os.path.dirname(os.path.realpath(__file__))
 
 RUN_DELAY = 15  # seconds

--- a/src/main.py
+++ b/src/main.py
@@ -17,7 +17,7 @@ from prometheus_client import start_http_server
 import config
 from pod_mgr import SeleniumPodMgr
 from runner import IqeRunner
-
+from tracker import init_tracker
 
 log = logging.getLogger("blackbox.main")
 RUNNERS = []
@@ -53,6 +53,8 @@ def main():
         if plugin_group:
             runner_name = f"runner-{i}"
             RUNNERS.append(IqeRunner(runner_name, plugin_group, pod_mgr, run_id=initial_run_id))
+
+    init_tracker(config.PLUGINS, RUNNERS)
 
     # Ensure number of selenium pods matches number runners
     switch_to_project(config.NAMESPACE)

--- a/src/runner.py
+++ b/src/runner.py
@@ -204,11 +204,8 @@ class IqeRunner(threading.Thread):
             while next(self.plugin_cycler).name != last_plugin:
                 continue
 
-        counter = 1
+        counter = 0
         while not self.stop_event.is_set():
-            if counter % len(self.plugins) == 1:
-                self._run_id += 1  # increase run id for each full loop through the plugin list
-
             plugin = next(self.plugin_cycler)
             if not plugin.last_completion or self._delay_passed(plugin):
                 self.run_plugin(plugin)
@@ -217,6 +214,9 @@ class IqeRunner(threading.Thread):
                 counter += 1
             else:
                 log.debug("[%s|run:%d] skipping due to time delay", plugin.name, self._run_id)
+
+            if counter % len(self.plugins) == 0:
+                self._run_id += 1  # increase run id for each full loop through the plugin list
             time.sleep(1)
 
     def stop(self):

--- a/src/runner.py
+++ b/src/runner.py
@@ -206,7 +206,7 @@ class IqeRunner(threading.Thread):
 
         counter = 1
         while not self.stop_event.is_set():
-            if counter == len(self.plugins):
+            if counter % len(self.plugins) == 1:
                 self._run_id += 1  # increase run id for each full loop through the plugin list
 
             plugin = next(self.plugin_cycler)

--- a/src/tracker.py
+++ b/src/tracker.py
@@ -1,0 +1,114 @@
+import json
+import logging
+import os
+import threading
+
+
+log = logging.getLogger("blackbox.tracker")
+TRACKER_FILE = os.path.join("/black-box-runner-storage", "tracker.json")
+_lock = threading.RLock()
+
+
+"""
+Example tracker file:
+{
+    "num_runners": 3,
+    "plugins": ["plugin1", "plugin2", "plugin3", "plugin4", "plugin5"]
+    "runners": [
+        {"name": "runner1", "plugins": ["plugin1", "plugin2"], "last_plugin": "plugin2"},
+        {"name": "runner2", "plugins": ["plugin3", "plugin4"], "last_plugin": "plugin3"},
+        {"name": "runner3", "plugins": ["plugin5"], "last_plugin": None}
+    ]
+}
+"""
+
+
+def locked(orig_func):
+    def _func(*args, **kwargs):
+        with _lock:
+            return orig_func(*args, **kwargs)
+
+    return _func
+
+
+@locked
+def read_tracker_data():
+    if not os.path.exists(TRACKER_FILE):
+        log.info("tracker file does not exist")
+        return {}
+    try:
+        with open(TRACKER_FILE) as fp:
+            data = fp.read()
+            log.debug("read tracker data: %s", data)
+            if not data.strip():
+                return {}
+            return json.loads(data)
+    except (OSError, json.decoder.JSONDecodeError):
+        log.exception("error reading tracker file")
+        return {}
+
+
+@locked
+def write_tracker_data(data):
+    try:
+        with open(TRACKER_FILE, "w") as fp:
+            json.dump(data, fp)
+    except OSError:
+        log.exception("error writing to tracker file")
+
+
+@locked
+def set_last_executed_plugin(runner_name, plugin_name):
+    data = read_tracker_data()
+    get_runner(runner_name, data)["last_plugin"] = plugin_name
+    write_tracker_data(data)
+
+
+def get_runner(runner_name, data=None):
+    if data:
+        runners = data.get("runners", [])
+    else:
+        runners = read_tracker_data().get("runners", [])
+    for r in runners:
+        if r["name"] == runner_name:
+            return r
+    return None
+
+
+def init_tracker(plugins, runners):
+    data = read_tracker_data()
+    current_plugin_names = [p[0] for p in plugins]
+
+    reset = False
+    if not data:
+        log.info("no tracker data found, re-initializing tracker")
+        reset = True
+    elif data.get("num_runners") != len(runners) or data.get("plugins") != current_plugin_names:
+        log.info("num runners or plugins have changed, re-initializing tracker")
+        reset = True
+    else:
+        for runner in runners:
+            stored_runner = get_runner(runner.name, data)
+            if not stored_runner:
+                log.info("runner %s not in tracker data, re-initializing tracker", runner.name)
+                reset = True
+            if stored_runner.get("plugins") != [p.name for p in runner.plugins]:
+                log.info(
+                    "runner %s assigned plugins changed, re-initializing tracker data", runner.name
+                )
+                reset = True
+
+    if reset:
+        fresh_data = {
+            "num_runners": len(runners),
+            "plugins": current_plugin_names,
+            "runners": [r.to_dict() for r in runners],
+        }
+        write_tracker_data(fresh_data)
+    else:
+        log.info("no change in plugins/runners -- using previously stored tracker data")
+    log.info("tracker data:\n%s", json.dumps(read_tracker_data(), sort_keys=True, indent=4))
+
+
+def get_last_executed_plugin(runner_name):
+    return get_runner(runner_name)["last_plugin"]


### PR DESCRIPTION
If the black box tester pod restarts, it will pick up executing from where it left off. We look at the last executed plugin, and the runners start tests at the plugin AFTER that one in their list. The plugin info is tracked in a json file stored in a persistent volume.